### PR TITLE
Improve game list UI: filters, grouping, mileage dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ __marimo__/
 
 # Media files
 media/
+
+# Session summaries
+*-session.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Unpaid/All toggle on game list: defaults to showing only unpaid, non-volunteer games on login.
+- Month grouping on game list: games collapsed by month with click-to-expand headers showing game count.
+- Date+site trip grouping: within each month, games at the same site on the same date are grouped under a trip sub-header showing mileage once rather than per game entry.
+
+### Fixed
+- Game list table was showing all games regardless of active filters; now correctly scoped to the filtered queryset.
+- Mileage display deduped per trip: mileage paid status reflects all games in the trip group.

--- a/tracker/templates/game/list.html
+++ b/tracker/templates/game/list.html
@@ -46,6 +46,17 @@
         {% endfor %}
       </select>
       <a href="{% url 'game_list' %}" class="w-full text-center text-sm px-2 py-1 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-300 dark:hover:bg-gray-500 transition">Clear Filters</a>
+
+      <div class="flex rounded overflow-hidden border border-gray-300 dark:border-gray-600 mt-1">
+        <a href="?filter_year={{ f_year }}&filter_league={{ f_league }}&filter_assignor={{ f_assignor }}&filter_position={{ f_position }}&filter_site={{ f_site }}&filter_paid=unpaid"
+           class="flex-1 text-center text-sm px-2 py-1 transition {% if f_paid == 'unpaid' %}bg-blue-600 text-white{% else %}bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600{% endif %}">
+          Unpaid
+        </a>
+        <a href="?filter_year={{ f_year }}&filter_league={{ f_league }}&filter_assignor={{ f_assignor }}&filter_position={{ f_position }}&filter_site={{ f_site }}&filter_paid=all"
+           class="flex-1 text-center text-sm px-2 py-1 transition {% if f_paid == 'all' %}bg-blue-600 text-white{% else %}bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600{% endif %}">
+          All
+        </a>
+      </div>
       {% endwith %}
     </form>
 
@@ -85,39 +96,59 @@
       </tr>
     </thead>
     <tbody>
-      {% for game in games %}
-      <tr class="border-t hover:bg-gray-50">
-        <td class="px-4 py-2">{{ game.date }}</td>
-        <td class="px-4 py-2">{{ game.site.name }}</td>
+      {% for month_label, date_site_groups, month_count in games_by_month %}
+      {% with mid=forloop.counter %}
+      <tr class="cursor-pointer select-none bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+          onclick="toggleMonth({{ mid }})">
+        <td colspan="8" class="px-4 py-2 font-semibold text-gray-700 dark:text-gray-200">
+          <span id="chev-{{ mid }}">{% if month_label == expand_month %}▼{% else %}▶{% endif %}</span>
+          {{ month_label }}
+          <span class="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">({{ month_count }} game{{ month_count|pluralize }})</span>
+        </td>
+      </tr>
+      {% for game_date, site_name, trip_mileage, trip_mileage_paid, ds_games in date_site_groups %}
+      <tr class="mg-{{ mid }} bg-blue-50 dark:bg-blue-900/20 border-t border-gray-200{% if month_label != expand_month %} hidden{% endif %}">
+        <td class="px-4 py-1 text-sm font-medium text-blue-800 dark:text-blue-200" colspan="2">{{ game_date|date:"D, N j" }} — {{ site_name }}</td>
+        <td colspan="3"></td>
+        <td class="px-4 py-1 text-sm text-gray-600 dark:text-gray-400">{% if trip_mileage > 0 %}{{ trip_mileage|floatformat:1 }} mi{% endif %}</td>
+        <td class="px-4 py-1">{% if trip_mileage_paid %}{% include 'game/icon-checkmark.html' %}{% endif %}</td>
+        <td></td>
+      </tr>
+      {% for game in ds_games %}
+      <tr class="mg-{{ mid }} border-t border-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800{% if month_label != expand_month %} hidden{% endif %}">
+        <td class="py-2 pl-8" colspan="2"></td>
         <td class="px-4 py-2">{{ game.league.organization }}</td>
         <td class="px-4 py-2">{% if game.position %}{{ game.position }}{% endif %}</td>
-        <td class="px-4 py-2">
-          {% if game.fee_paid %}
-            {% include 'game/icon-checkmark.html' %}
-          {% endif %}
-        </td>
-        <td class="px-4 py-2">{% if game.mileage > 0 %}{{ game.mileage }}{% endif %}</td>
-        <td class="px-4 py-2">
-          {% if game.mileage_paid %}
-            {% include 'game/icon-checkmark.html' %}
-          {% endif %}
-        </td>
+        <td class="px-4 py-2">{% if game.fee_paid %}{% include 'game/icon-checkmark.html' %}{% endif %}</td>
+        <td></td>
+        <td></td>
         <td class="px-4 py-2 space-x-2">
-
           <form method="get" action="{% url 'edit_game' game.id %}" class="inline">
-            <button type="submit" class="px-3 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600 transition">
-              Edit
-            </button>
+            <button type="submit" class="px-3 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600 transition">Edit</button>
           </form>
           <form method="post" action="{% url 'delete_game' game.id %}" class="inline" onsubmit="return confirm('Are you sure you want to delete this item?');">
             {% csrf_token %}
-            <button type="submit" class="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition">
-              Delete
-            </button>
+            <button type="submit" class="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition">Delete</button>
           </form>
         </td>
       </tr>
       {% endfor %}
+      {% endfor %}
+      {% endwith %}
+      {% empty %}
+      <tr><td colspan="8" class="px-4 py-6 text-center text-gray-400 dark:text-gray-500">No games match the current filters.</td></tr>
+      {% endfor %}
     </tbody>
   </table>
+
+  <style>tr.hidden { display: none !important; }</style>
+  <script>
+    function toggleMonth(id) {
+      const rows = document.querySelectorAll(`.mg-${id}`);
+      const chev = document.getElementById(`chev-${id}`);
+      const collapsed = rows.length > 0 && rows[0].classList.contains('hidden');
+      rows.forEach(r => r.classList.toggle('hidden', !collapsed));
+      chev.textContent = collapsed ? '▼' : '▶';
+    }
+  </script>
 {% endblock %}

--- a/tracker/views.py
+++ b/tracker/views.py
@@ -1,4 +1,5 @@
 from datetime import date
+from itertools import groupby
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -69,6 +70,7 @@ def game_list(request: HttpRequest) -> HttpResponse:
     f_assignor = request.GET.get("filter_assignor", "")
     f_position = request.GET.get("filter_position", "")
     f_site = request.GET.get("filter_site", "")
+    f_paid = request.GET.get("filter_paid", "unpaid")
 
     summary_qs = games
     if f_year:
@@ -81,6 +83,8 @@ def game_list(request: HttpRequest) -> HttpResponse:
         summary_qs = summary_qs.filter(position=f_position)
     if f_site:
         summary_qs = summary_qs.filter(site__name=f_site)
+    if f_paid == "unpaid":
+        summary_qs = summary_qs.filter(fee_paid=False, is_volunteer=False)
 
     eff_fee = Case(
         When(fee__isnull=False, then=F("fee")),
@@ -93,6 +97,30 @@ def game_list(request: HttpRequest) -> HttpResponse:
         paid_fees=Sum(eff_fee, filter=Q(fee_paid=True)),
         unpaid_fees=Sum(eff_fee, filter=Q(fee_paid=False, is_volunteer=False)),
         total_mileage=Sum("mileage"),
+    )
+
+    games_list = list(summary_qs.order_by("date", "site__name"))
+    games_by_month = []
+    for month_label, month_group in groupby(
+        games_list, key=lambda g: g.date.strftime("%B %Y")
+    ):
+        month_games = list(month_group)
+        date_site_groups = []
+        for (gdate, sid), ds_iter in groupby(
+            month_games, key=lambda g: (g.date, g.site_id)
+        ):
+            ds_games = list(ds_iter)
+            site_name = ds_games[0].site.name if ds_games[0].site else ""
+            trip_mileage = max((g.mileage for g in ds_games), default=0)
+            trip_mileage_paid = trip_mileage > 0 and all(
+                g.mileage_paid for g in ds_games
+            )
+            date_site_groups.append(
+                (gdate, site_name, trip_mileage, trip_mileage_paid, ds_games)
+            )
+        games_by_month.append((month_label, date_site_groups, len(month_games)))
+    expand_month = (
+        games_by_month[-1][0] if games_by_month else date.today().strftime("%B %Y")
     )
 
     available_years = list(
@@ -128,7 +156,8 @@ def game_list(request: HttpRequest) -> HttpResponse:
     )
 
     context = {
-        "games": games,
+        "games_by_month": games_by_month,
+        "expand_month": expand_month,
         "title": "Game List",
         "form": form,
         "summary": summary,
@@ -138,6 +167,7 @@ def game_list(request: HttpRequest) -> HttpResponse:
         "f_assignor": f_assignor,
         "f_position": f_position,
         "f_site": f_site,
+        "f_paid": f_paid,
         "available_years": available_years,
         "available_leagues": available_leagues,
         "available_assignors": available_assignors,


### PR DESCRIPTION
## Summary

- Fix filter bug: game list table was showing all games regardless of active year/league/site filters
- Add Unpaid/All toggle defaulting to unpaid on login, so users immediately see games needing action
- Group games by month with collapsible headers (most recent expanded, prior collapsed)
- Nest games by date+site with a trip sub-header showing mileage once per trip rather than per game entry

## Test plan

- [ ] Log in and confirm game list defaults to current year + unpaid games only
- [ ] Confirm Unpaid/All toggle switches correctly while preserving other active filters
- [ ] Confirm month headers collapse and expand on click; chevron flips accordingly
- [ ] Confirm games at the same site on the same date are grouped under one trip sub-header with a single mileage value
- [ ] Confirm mileage paid checkmark on trip header only appears when all games in the group are marked paid
- [ ] Confirm Clear Filters resets to current year + unpaid default
- [ ] Confirm filter dropdowns (year, league, assignor, position, site) still show all available options regardless of active filters