### PR TITLE
UI fixes: stats whole dollars and responsive summary widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Unpaid/All toggle on game list: defaults to showing only unpaid, non-volunteer games on login.
 - Month grouping on game list: games collapsed by month with click-to-expand headers showing game count.
 - Date+site trip grouping: within each month, games at the same site on the same date are grouped under a trip sub-header showing mileage once rather than per game entry.
+- PRD and task JSON for game list UX improvements (`plans/game-list-ux-improvements-prd.md`, `plans/game-list-ux-improvements-prd.json`).
+
+### Changed
+- Stats page fee columns (Total Fees, Paid, Unpaid) now display as whole dollars with no decimal places across all five stat tables.
+- Game list summary widget is now responsive: single-column stack on mobile (below 640px), 2x2 grid on wider viewports.
 
 ### Fixed
 - Game list table was showing all games regardless of active filters; now correctly scoped to the filtered queryset.

--- a/plans/game-list-ux-improvements-prd.json
+++ b/plans/game-list-ux-improvements-prd.json
@@ -1,0 +1,180 @@
+[
+  {
+    "task": "Remove Site column from game list table",
+    "category": "ui",
+    "priority": "high",
+    "done": false,
+    "description": "Delete the Site <th> header and all per-row <td> site cells from tracker/templates/game/list.html. Update colspan values on month group rows, date-site trip rows, and empty-state row to match the new 7-column layout.",
+    "files_affected": [
+      "tracker/templates/game/list.html"
+    ],
+    "acceptance_criteria": [
+      "Site column header is absent from the table",
+      "No site data cells appear in any game row",
+      "colspan values are consistent across all row types",
+      "No layout breakage in collapsed or expanded month groups"
+    ],
+    "steps": [
+      "Remove <th class=\"px-4 py-2 text-left\">Site</th> from thead",
+      "Remove the site <td> from date-site trip row (currently colspan=2)",
+      "Remove site display from per-game row",
+      "Audit all colspan attributes and decrement by 1 where needed"
+    ]
+  },
+  {
+    "task": "Add Fee column and inline paid toggle to game list rows",
+    "category": "feature",
+    "priority": "high",
+    "done": false,
+    "description": "Add a Fee column to each per-game row showing the fee as a whole-dollar amount. Add an icon button (SVG, consistent with icon-checkmark.html) that POSTs to a toggle endpoint via fetch/XHR and updates the icon in place on success.",
+    "files_affected": [
+      "tracker/templates/game/list.html",
+      "tracker/templates/game/icon-checkmark.html",
+      "tracker/views.py",
+      "tracker/urls.py"
+    ],
+    "acceptance_criteria": [
+      "Fee amount shown as $N (whole dollars) in each game row",
+      "Toggle icon shows paid/unpaid state visually",
+      "Click sends one POST; icon updates without page reload",
+      "Error case reverts icon, does not silently fail"
+    ],
+    "steps": [
+      "Add Fee and Paid toggle <th> headers to thead",
+      "Add <td> with fee display and toggle icon button to each game row",
+      "Create toggle_fee_paid view in views.py returning JSON",
+      "Add URL route for toggle_fee_paid",
+      "Add inline JS in list.html to handle fetch POST and DOM update"
+    ]
+  },
+  {
+    "task": "Replace Edit/Delete text buttons with icon buttons",
+    "category": "ui",
+    "priority": "medium",
+    "done": false,
+    "description": "Replace the Edit (yellow) and Delete (red) text buttons with SVG pen and X icon buttons respectively. Retain existing form actions, CSRF handling, and confirm dialog. Add aria-label to each.",
+    "files_affected": [
+      "tracker/templates/game/list.html"
+    ],
+    "acceptance_criteria": [
+      "Edit renders as pen SVG icon with aria-label=\"Edit game\"",
+      "Delete renders as X SVG icon with aria-label=\"Delete game\"",
+      "Confirm dialog on delete is preserved",
+      "CSRF token remains in delete form"
+    ],
+    "steps": [
+      "Replace Edit button text with inline SVG pen icon",
+      "Replace Delete button text with inline SVG X icon",
+      "Add aria-label attributes to both buttons",
+      "Verify visual consistency with existing icon patterns"
+    ]
+  },
+  {
+    "task": "Convert Unpaid/All toggle to client-side filtering",
+    "category": "feature",
+    "priority": "high",
+    "done": false,
+    "description": "Add data-paid attribute to each per-game row. Replace the current <a> link toggle with JS that shows/hides rows based on data-paid value, updating active tab styling. No page reload on toggle.",
+    "files_affected": [
+      "tracker/templates/game/list.html"
+    ],
+    "acceptance_criteria": [
+      "Unpaid tab hides rows where data-paid=true",
+      "All tab shows all rows regardless of data-paid",
+      "Active tab styling updates immediately on click",
+      "No network request fires when toggling"
+    ],
+    "steps": [
+      "Add data-paid=\"{{ game.fee_paid|yesno:'true,false' }}\" to each game row <tr>",
+      "Convert Unpaid/All <a> links to <button> elements with JS onclick handlers",
+      "Write togglePaidFilter(mode) JS function to show/hide .mg-N rows by data-paid",
+      "Initialize correct tab state on page load based on current f_paid value"
+    ]
+  },
+  {
+    "task": "Display stats fee columns as whole dollars",
+    "category": "ui",
+    "priority": "medium",
+    "done": false,
+    "description": "Change all floatformat:2 filters on fee values in stats.html to floatformat:0. Applies to Total Fees, Paid Fees, and Unpaid Fees across all five stat tables.",
+    "files_affected": [
+      "tracker/templates/game/stats.html"
+    ],
+    "acceptance_criteria": [
+      "All dollar values in By Year table show no decimal places",
+      "All dollar values in By League table show no decimal places",
+      "All dollar values in By Assignor table show no decimal places",
+      "All dollar values in By Position table show no decimal places",
+      "All dollar values in By Site table show no decimal places"
+    ],
+    "steps": [
+      "Replace all occurrences of floatformat:2 with floatformat:0 on fee fields in stats.html"
+    ]
+  },
+  {
+    "task": "Add toggle_fee_paid backend endpoint",
+    "category": "backend",
+    "priority": "high",
+    "done": false,
+    "description": "Create a POST-only view that toggles game.fee_paid for the authenticated user's game and returns JSON {\"fee_paid\": bool}. Protect with @login_required and return 404 for games not owned by request.user.",
+    "files_affected": [
+      "tracker/views.py",
+      "tracker/urls.py"
+    ],
+    "acceptance_criteria": [
+      "POST to /games/<id>/toggle-paid/ flips fee_paid and returns JSON",
+      "Non-POST requests return 405",
+      "Games belonging to other users return 404",
+      "Endpoint requires login; unauthenticated requests redirect to login"
+    ],
+    "steps": [
+      "Add toggle_fee_paid(request, pk) view with @login_required",
+      "Use get_object_or_404(Game, pk=pk, user=request.user) for ownership check",
+      "Toggle game.fee_paid and save",
+      "Return JsonResponse({\"fee_paid\": game.fee_paid})",
+      "Add path('games/<int:pk>/toggle-paid/', views.toggle_fee_paid, name='toggle_fee_paid') to urls.py"
+    ]
+  },
+  {
+    "task": "Remove h3 headers and add collapsible sections to Stats page",
+    "category": "ui",
+    "priority": "medium",
+    "done": false,
+    "description": "The h3 label above each stats section duplicates the first-column heading already present in the table (e.g., 'By Year'). Remove all five h3 elements and replace each section with a collapsible block toggled by a button displaying the section name. By Year and By League expand on load; By Assignor, By Position, By Site collapse on load. State managed client-side.",
+    "files_affected": [
+      "tracker/templates/game/stats.html"
+    ],
+    "acceptance_criteria": [
+      "All five h3 section headers are removed",
+      "Each section has a clickable toggle button showing the section name",
+      "By Year and By League are expanded on initial page load",
+      "By Assignor, By Position, and By Site are collapsed on initial page load",
+      "Toggling a section shows or hides its table with no page reload"
+    ],
+    "steps": [
+      "Replace each <section> opening with a <details>/<summary> or button+div collapsible pattern",
+      "Set By Year and By League open by default; leave others closed",
+      "Remove all five <h3> elements",
+      "Add consistent chevron indicator that rotates on expand/collapse",
+      "Verify keyboard accessibility of toggle controls"
+    ]
+  },
+  {
+    "task": "Make game list summary widget responsive for mobile",
+    "category": "ui",
+    "priority": "medium",
+    "done": false,
+    "description": "The summary widget (Games, Total Fees, Unpaid, Miles) uses a fixed grid-cols-2 layout. On narrow viewports this produces a cramped 2x2 grid. Change to grid-cols-1 on mobile and grid-cols-2 on sm: and wider using Tailwind responsive prefixes.",
+    "files_affected": [
+      "tracker/templates/game/list.html"
+    ],
+    "acceptance_criteria": [
+      "Summary displays as a single column on viewports narrower than 640px",
+      "Summary displays as 2x2 on viewports 640px and wider",
+      "No change to content, labels, or values"
+    ],
+    "steps": [
+      "Change grid-cols-2 to grid-cols-1 sm:grid-cols-2 on the summary grid div"
+    ]
+  }
+]

--- a/plans/game-list-ux-improvements-prd.md
+++ b/plans/game-list-ux-improvements-prd.md
@@ -1,0 +1,73 @@
+# Improve Game List UX and Stats Readability
+
+## Overview
+
+Refine the game list and stats pages to reduce visual noise, speed up the most common user action (marking a game paid), and display financial figures consistently as whole dollars. These changes follow the recent UI layout work on the `ui-enhance` branch and address friction points identified in daily use.
+
+## Goals
+
+1. Game list table renders without the Site column, reducing horizontal clutter.
+2. Users can mark a game paid or unpaid directly from the list in one click, without opening the edit form.
+3. Toggling between Unpaid and All views happens instantly (no page reload) by filtering already-loaded data.
+4. Edit and Delete affordances use icon buttons, reducing visual weight while remaining accessible.
+5. Stats page displays all dollar amounts as whole integers, improving scannability.
+6. Stats page sections are collapsible; the section label in the first column makes the h3 header redundant and removing it reduces visual weight.
+7. The game list summary widget adapts from a 2x2 grid on wide viewports to a single-column list on mobile, preventing cramped layout on small screens.
+
+## Non-goals
+
+- No changes to mileage display or mileage-paid logic.
+- No changes to the Add Game form or any other page.
+- No backend API refactor; the inline paid toggle uses an existing or minimal new endpoint.
+- No changes to filter behavior beyond the Unpaid/All client-side toggle.
+
+## User stories
+
+- As an official, I want to mark a game paid directly from the game list so that I do not have to open the edit form for a routine payment update.
+- As an official, I want to switch between Unpaid and All games instantly so that I can scan my payment status without waiting for a page reload.
+- As an official, I want the stats tables to show dollar amounts without cents so that financial totals are easier to read at a glance.
+- As an official, I want icon-only Edit and Delete buttons so that the game list feels less cluttered and I can act on rows quickly.
+- As an official, I want to collapse stats sections I am not focused on so that the page is less overwhelming and I can scan what matters.
+- As an official viewing the game list on my phone, I want the summary figures to stack in a readable single column so that I do not have to squint at a cramped 2x2 grid.
+
+## Requirements
+
+1. Remove the Site column (`<th>` and all `<td>` cells) from `tracker/templates/game/list.html`. The table colspan counts must be updated to match.
+2. Add a Fee column to the per-game rows in `list.html` that displays the game fee amount (e.g., `$75`).
+3. Add an inline paid toggle icon button to each per-game row. Clicking it sends a POST to a toggle endpoint and updates the icon in place without a full page reload (AJAX or htmx-style form).
+4. The toggle icon must visually distinguish paid (checkmark/green) from unpaid (dollar/gray) states and update immediately on success.
+5. Replace the Edit text button with a pen icon button and the Delete text button with an X icon button. Both must retain their existing behavior and CSRF handling. Accessible `aria-label` attributes are required on each icon button.
+6. The Unpaid / All toggle must filter rows client-side using a `data-paid` attribute on each row, with no HTTP request. The URL query param may still reflect the state for bookmarking.
+7. Replace `floatformat:2` with `floatformat:0` on all fee columns in `tracker/templates/game/stats.html` (By Year, By League, By Assignor, By Position, By Site tables).
+8. A new URL route and view method (e.g., `toggle_fee_paid`) must handle the AJAX POST for requirement 3, returning JSON `{"fee_paid": true/false}` and requiring `@login_required`.
+9. Remove the `<h3>` section headers from each stats section in `stats.html`. Replace each `<section>` with a collapsible block whose toggle button displays the section name (e.g., "By Year"). By Year and By League expand by default; By Assignor, By Position, and By Site collapse by default. State is managed client-side via JS; no server round-trip.
+10. Change the game list summary grid from `grid-cols-2` (fixed 2x2) to a responsive layout: `grid-cols-1` on mobile, `grid-cols-2` on `sm:` and wider. No change to the data or labels displayed.
+
+## Acceptance criteria
+
+- [ ] R1: The Site column header and all site data cells are absent from the game list table.
+- [ ] R1: Table colspan values are consistent; no broken layout in collapsed or expanded month rows.
+- [ ] R2: Each per-game row shows the fee amount formatted as a whole-dollar integer (e.g., `$75`, not `$75.00`).
+- [ ] R3: Clicking the paid toggle icon on a game row sends exactly one POST to the toggle endpoint without navigating away.
+- [ ] R4: After a successful toggle, the icon updates to reflect the new paid state without a page reload.
+- [ ] R4: If the server returns an error, the icon reverts and no silent failure occurs.
+- [ ] R5: Edit button renders as a pen SVG icon with `aria-label="Edit game"`.
+- [ ] R5: Delete button renders as an X SVG icon with `aria-label="Delete game"`. Existing confirm dialog is preserved.
+- [ ] R6: Clicking Unpaid shows only rows where `data-paid="false"`; clicking All shows all rows. No network request fires on toggle.
+- [ ] R6: The active tab styling updates on click.
+- [ ] R7: All fee cells in stats.html show values rounded to the nearest dollar with no decimal point.
+- [ ] R8: The toggle endpoint is protected by `@login_required` and rejects non-POST requests with 405.
+- [ ] R8: The endpoint only toggles games owned by the authenticated user; a 404 is returned for games belonging to other users.
+- [ ] R9: Each `<h3>` section header is removed from stats.html.
+- [ ] R9: Each stats section renders as a collapsible block with a toggle button showing the section name.
+- [ ] R9: By Year and By League are expanded on initial page load; By Assignor, By Position, and By Site are collapsed.
+- [ ] R9: Toggling a section shows or hides its table with no page reload.
+- [ ] R10: The summary grid displays as a single column on viewports narrower than the Tailwind `sm` breakpoint (640px).
+- [ ] R10: The summary grid displays as 2x2 on `sm:` and wider viewports.
+- [ ] R10: No change to the content, labels, or values in the summary widget.
+
+## Open questions
+
+- Should the fee toggle icon button be an SVG inline or a Unicode character? SVG preferred for consistency with the existing `icon-checkmark.html` include pattern, but confirm before implementing.
+- The client-side Unpaid/All toggle currently preserves the active filter state in the URL via `<a>` links that trigger a GET. Replacing with JS filtering means the URL will not update unless we push to history. Is URL persistence required for this toggle?
+- Should the Stats page currency columns include a `$` prefix after the format change, or is the existing `$` literal in the template sufficient?

--- a/tracker/templates/game/list.html
+++ b/tracker/templates/game/list.html
@@ -60,7 +60,7 @@
       {% endwith %}
     </form>
 
-    <div class="flex-1 grid grid-cols-2 gap-4 content-center">
+    <div class="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-4 content-center">
       <div class="text-center">
         <div class="text-xs text-gray-500 dark:text-gray-400">Games</div>
         <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">{{ summary.count|default:"0" }}</div>

--- a/tracker/templates/game/stats.html
+++ b/tracker/templates/game/stats.html
@@ -18,8 +18,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Year</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
-          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>
@@ -51,8 +51,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">League</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
-          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>
@@ -84,8 +84,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Assignor</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
-          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>
@@ -117,8 +117,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Position</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
-          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>
@@ -150,8 +150,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Site</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
-          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
+          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>

--- a/tracker/templates/game/stats.html
+++ b/tracker/templates/game/stats.html
@@ -28,9 +28,9 @@
         <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
           <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.year }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0.00"|floatformat:2 }}</td>
+          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
         </tr>
         {% empty %}
@@ -61,9 +61,9 @@
         <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
           <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.league__organization|default:"—" }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0.00"|floatformat:2 }}</td>
+          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
         </tr>
         {% empty %}
@@ -94,9 +94,9 @@
         <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
           <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.league__assignor|default:"—" }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0.00"|floatformat:2 }}</td>
+          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
         </tr>
         {% empty %}
@@ -127,9 +127,9 @@
         <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
           <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.position|default:"—" }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0.00"|floatformat:2 }}</td>
+          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
         </tr>
         {% empty %}
@@ -160,9 +160,9 @@
         <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
           <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.site__name|default:"—" }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0.00"|floatformat:2 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0.00"|floatformat:2 }}</td>
+          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
+          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
           <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
         </tr>
         {% empty %}

--- a/tracker/templates/game/stats.html
+++ b/tracker/templates/game/stats.html
@@ -18,8 +18,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Year</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
+          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
+          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>
@@ -51,8 +51,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">League</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
+          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
+          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>
@@ -84,8 +84,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Assignor</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
+          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
+          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>
@@ -117,8 +117,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Position</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
+          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
+          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>
@@ -150,8 +150,8 @@
           <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Site</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
+          <th class="px-4 py-2 text-right text-green-600 dark:text-green-400">Paid</th>
+          <th class="px-4 py-2 text-right text-red-600 dark:text-red-400">Unpaid</th>
           <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
         </tr>
       </thead>


### PR DESCRIPTION
## Summary

- Closes #82: Stats page fee columns (Total Fees, Paid, Unpaid) now display as whole dollars across all five tables (By Year, By League, By Assignor, By Position, By Site)
- Closes #84: Game list summary widget (Games, Total Fees, Unpaid, Miles) stacks to a single column on mobile viewports below 640px, restoring the 2x2 grid at `sm:` and wider
- Adds PRD and task JSON for the remaining game list UX work (#78–#83)

## Test plan

- [ ] Visit the Stats page and verify all dollar values show no decimal places in every table
- [ ] Narrow the game list page below 640px and confirm the summary widget stacks to a 1x4 column
- [ ] Widen above 640px and confirm the summary widget returns to a 2x2 grid
- [ ] No regressions on mileage display (remains `floatformat:1`)