### PR TITLE
feat(game-list): add inline fee display and paid toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- Fee column in game list: shows effective fee per game as whole dollars ($N); volunteer games show a dash.
+- Paid toggle in game list: single-click icon in each game row fires a POST to `toggle_fee_paid`, flips `fee_paid` in place without page reload, and reverts with an alert on server error.
+- `POST /game/<id>/toggle-paid/` endpoint: flips `fee_paid`, returns `{"fee_paid": bool}`; requires login, 405 on non-POST, 404 for other users' games.
 - Unpaid/All toggle on game list: defaults to showing only unpaid, non-volunteer games on login.
 - Month grouping on game list: games collapsed by month with click-to-expand headers showing game count.
 - Date+site trip grouping: within each month, games at the same site on the same date are grouped under a trip sub-header showing mileage once rather than per game entry.

--- a/tracker/templates/game/list.html
+++ b/tracker/templates/game/list.html
@@ -89,7 +89,8 @@
         <th class="px-4 py-2 text-left">Site</th>
         <th class="px-4 py-2 text-left">League</th>
         <th class="px-4 py-2 text-left">Position</th>
-        <th class="px-4 py-2 text-left">Fee Paid</th>
+        <th class="px-4 py-2 text-left">Fee</th>
+        <th class="px-4 py-2 text-left">Paid</th>
         <th class="px-4 py-2 text-left">Mileage</th>
         <th class="px-4 py-2 text-left">Mileage Paid</th>
         <th class="px-4 py-2 text-left"></th>
@@ -100,7 +101,7 @@
       {% with mid=forloop.counter %}
       <tr class="cursor-pointer select-none bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
           onclick="toggleMonth({{ mid }})">
-        <td colspan="8" class="px-4 py-2 font-semibold text-gray-700 dark:text-gray-200">
+        <td colspan="9" class="px-4 py-2 font-semibold text-gray-700 dark:text-gray-200">
           <span id="chev-{{ mid }}">{% if month_label == expand_month %}▼{% else %}▶{% endif %}</span>
           {{ month_label }}
           <span class="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">({{ month_count }} game{{ month_count|pluralize }})</span>
@@ -109,7 +110,7 @@
       {% for game_date, site_name, trip_mileage, trip_mileage_paid, ds_games in date_site_groups %}
       <tr class="mg-{{ mid }} bg-blue-50 dark:bg-blue-900/20 border-t border-gray-200{% if month_label != expand_month %} hidden{% endif %}">
         <td class="px-4 py-1 text-sm font-medium text-blue-800 dark:text-blue-200" colspan="2">{{ game_date|date:"D, N j" }} — {{ site_name }}</td>
-        <td colspan="3"></td>
+        <td colspan="4"></td>
         <td class="px-4 py-1 text-sm text-gray-600 dark:text-gray-400">{% if trip_mileage > 0 %}{{ trip_mileage|floatformat:1 }} mi{% endif %}</td>
         <td class="px-4 py-1">{% if trip_mileage_paid %}{% include 'game/icon-checkmark.html' %}{% endif %}</td>
         <td></td>
@@ -119,7 +120,20 @@
         <td class="py-2 pl-8" colspan="2"></td>
         <td class="px-4 py-2">{{ game.league.organization }}</td>
         <td class="px-4 py-2">{% if game.position %}{{ game.position }}{% endif %}</td>
-        <td class="px-4 py-2">{% if game.fee_paid %}{% include 'game/icon-checkmark.html' %}{% endif %}</td>
+        <td class="px-4 py-2 text-sm">{% if not game.is_volunteer %}${{ game.eff_fee_val|default:0|floatformat:0 }}{% else %}—{% endif %}</td>
+        <td class="px-4 py-2">
+          <button class="fee-toggle cursor-pointer hover:opacity-75 transition"
+              data-game-id="{{ game.id }}"
+              data-paid="{{ game.fee_paid|yesno:'true,false' }}"
+              data-url="{% url 'toggle_fee_paid' game.id %}"
+              title="{% if game.fee_paid %}Paid — click to mark unpaid{% else %}Unpaid — click to mark paid{% endif %}">
+            {% if game.fee_paid %}
+              <svg class="inline-block text-green-600" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+            {% else %}
+              <svg class="inline-block text-gray-400" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+            {% endif %}
+          </button>
+        </td>
         <td></td>
         <td></td>
         <td class="px-4 py-2 space-x-2">
@@ -136,7 +150,7 @@
       {% endfor %}
       {% endwith %}
       {% empty %}
-      <tr><td colspan="8" class="px-4 py-6 text-center text-gray-400 dark:text-gray-500">No games match the current filters.</td></tr>
+      <tr><td colspan="9" class="px-4 py-6 text-center text-gray-400 dark:text-gray-500">No games match the current filters.</td></tr>
       {% endfor %}
     </tbody>
   </table>
@@ -150,5 +164,39 @@
       rows.forEach(r => r.classList.toggle('hidden', !collapsed));
       chev.textContent = collapsed ? '▼' : '▶';
     }
+
+    const ICON_PAID = `<svg class="inline-block text-green-600" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`;
+    const ICON_UNPAID = `<svg class="inline-block text-gray-400" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`;
+
+    function getCsrfToken() {
+      const m = document.cookie.match(/csrftoken=([^;]+)/);
+      return m ? m[1] : '';
+    }
+
+    document.querySelectorAll('.fee-toggle').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const wasPaid = btn.dataset.paid === 'true';
+        btn.dataset.paid = wasPaid ? 'false' : 'true';
+        btn.innerHTML = wasPaid ? ICON_UNPAID : ICON_PAID;
+        btn.disabled = true;
+        try {
+          const res = await fetch(btn.dataset.url, {
+            method: 'POST',
+            headers: {'X-CSRFToken': getCsrfToken()},
+          });
+          if (!res.ok) throw new Error('Server error ' + res.status);
+          const data = await res.json();
+          btn.dataset.paid = data.fee_paid ? 'true' : 'false';
+          btn.innerHTML = data.fee_paid ? ICON_PAID : ICON_UNPAID;
+        } catch {
+          btn.dataset.paid = wasPaid ? 'true' : 'false';
+          btn.innerHTML = wasPaid ? ICON_PAID : ICON_UNPAID;
+          alert('Could not update payment status. Please try again.');
+        } finally {
+          btn.disabled = false;
+        }
+      });
+    });
   </script>
 {% endblock %}

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path("add_game/", views.game_create, name="add_game"),
     path("edit_game/<int:pk>/", views.edit_game, name="edit_game"),
     path("delete_game/<int:pk>/", views.delete_game, name="delete_game"),
+    path("game/<int:pk>/toggle-paid/", views.toggle_fee_paid, name="toggle_fee_paid"),
     path("site_distance/", views.site_distance, name="site_distance"),
     path("stats/", views.game_stats, name="game_stats"),
 ]

--- a/tracker/views.py
+++ b/tracker/views.py
@@ -5,9 +5,10 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Case, Count, DecimalField, F, Q, Sum, When
 from django.db.models.functions import ExtractYear
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
+from django.views.decorators.http import require_POST
 
 from tracker.forms import GameForm, ProfileForm, UserForm
 from tracker.models import Game, Site
@@ -99,7 +100,9 @@ def game_list(request: HttpRequest) -> HttpResponse:
         total_mileage=Sum("mileage"),
     )
 
-    games_list = list(summary_qs.order_by("date", "site__name"))
+    games_list = list(
+        summary_qs.annotate(eff_fee_val=eff_fee).order_by("date", "site__name")
+    )
     games_by_month = []
     for month_label, month_group in groupby(
         games_list, key=lambda g: g.date.strftime("%B %Y")
@@ -222,6 +225,15 @@ def delete_game(request: HttpRequest, pk: int) -> HttpResponse:
         return redirect("game_list")
     context = {"game": game, "title": "Delete Game"}
     return render(request, "game/delete.html", context)
+
+
+@login_required
+@require_POST
+def toggle_fee_paid(request: HttpRequest, pk: int) -> JsonResponse:
+    game = get_object_or_404(Game, pk=pk, user=request.user)
+    game.fee_paid = not game.fee_paid
+    game.save(update_fields=["fee_paid"])
+    return JsonResponse({"fee_paid": game.fee_paid})
 
 
 @login_required


### PR DESCRIPTION
Closes #79.

Marking a game as paid is the most frequent post-game action but previously required navigating to the edit form. This PR adds a Fee column and a single-click paid/unpaid toggle to each game row.

## Changes

- `tracker/views.py`: new `toggle_fee_paid` view (POST-only, `@login_required`, 404 for other users' games, returns `{"fee_paid": bool}`); `game_list` annotates each game with `eff_fee_val` (game-level fee overrides league fee) for per-row display
- `tracker/urls.py`: adds `game/<int:pk>/toggle-paid/`
- `tracker/templates/game/list.html`: Fee column showing `$N` whole dollars (dash for volunteer games); Paid column replaces static checkmark with a clickable toggle button; JS sends optimistic POST with CSRF cookie token, updates icon in place, reverts and alerts on server error

## How to test

1. `python3 manage.py runserver` and log in
2. Navigate to `/games/` -- confirm a Fee column appears next to Position showing dollar amounts
3. Click a paid icon (green checkmark) -- it should flip to gray dollar-circle without a page reload; reload to confirm DB updated
4. Click an unpaid icon -- should flip to green checkmark; reload to confirm
5. Open browser devtools, block the `/toggle-paid/` URL, click a toggle -- confirm the icon reverts and an alert appears
6. `curl -X GET /game/1/toggle-paid/` -- confirm 405 response
7. Log out, attempt `POST /game/1/toggle-paid/` -- confirm redirect to login

## Risk

New endpoint is narrow (single field update, scoped to `request.user`). No schema changes. The `eff_fee_val` annotation reuses the existing `Case/When` expression already used for summary aggregation, so query structure is unchanged.

The `filter_paid=unpaid` default hides paid games; toggling a game to paid will cause it to disappear from the default view on next render. This is existing behavior and expected.