### PR TITLE
feat: client-side paid filter, collapsible stats, thousands separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Added
+- Collapsible sections on Stats page: Year and League expand on load; Assignor, Position, and Site collapse. Toggle buttons have a bordered rectangle style with left-side chevron; first-column table header removed (button label serves as the group title); smooth CSS grid transition on expand/collapse.
+
+### Changed
+- Unpaid/All toggle on game list is now client-side: all game rows render in DOM with `data-paid` attribute; toggling hides/shows rows instantly with no page reload or network request. Initial tab state still reflects the `f_paid` query param.
+
+---
+
 - Fee column in game list: shows effective fee per game as whole dollars ($N); volunteer games show a dash.
 - Paid toggle in game list: single-click icon in each game row fires a POST to `toggle_fee_paid`, flips `fee_paid` in place without page reload, and reverts with an alert on server error.
 - `POST /game/<id>/toggle-paid/` endpoint: flips `fee_paid`, returns `{"fee_paid": bool}`; requires login, 405 on non-POST, 404 for other users' games.

--- a/project/settings.py
+++ b/project/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.humanize",
     "django.contrib.sites",
     "allauth",
     "allauth.account",

--- a/tracker/templates/game/list.html
+++ b/tracker/templates/game/list.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load humanize %}
 
 {% block title %} Game List {% endblock %}
 
@@ -48,34 +49,34 @@
       <a href="{% url 'game_list' %}" class="w-full text-center text-sm px-2 py-1 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-300 dark:hover:bg-gray-500 transition">Clear Filters</a>
 
       <div class="flex rounded overflow-hidden border border-gray-300 dark:border-gray-600 mt-1">
-        <a href="?filter_year={{ f_year }}&filter_league={{ f_league }}&filter_assignor={{ f_assignor }}&filter_position={{ f_position }}&filter_site={{ f_site }}&filter_paid=unpaid"
+        <button type="button" id="btn-paid-unpaid"
            class="flex-1 text-center text-sm px-2 py-1 transition {% if f_paid == 'unpaid' %}bg-blue-600 text-white{% else %}bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600{% endif %}">
           Unpaid
-        </a>
-        <a href="?filter_year={{ f_year }}&filter_league={{ f_league }}&filter_assignor={{ f_assignor }}&filter_position={{ f_position }}&filter_site={{ f_site }}&filter_paid=all"
+        </button>
+        <button type="button" id="btn-paid-all"
            class="flex-1 text-center text-sm px-2 py-1 transition {% if f_paid == 'all' %}bg-blue-600 text-white{% else %}bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600{% endif %}">
           All
-        </a>
+        </button>
       </div>
       {% endwith %}
     </form>
 
-    <div class="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-4 content-center">
+    <div class="flex-1 grid grid-cols-1 lg:grid-cols-2 gap-4 content-center">
       <div class="text-center">
         <div class="text-xs text-gray-500 dark:text-gray-400">Games</div>
-        <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">{{ summary.count|default:"0" }}</div>
+        <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">{{ summary.count|default:"0"|intcomma }}</div>
       </div>
       <div class="text-center">
         <div class="text-xs text-gray-500 dark:text-gray-400">Total Fees</div>
-        <div class="text-2xl font-bold text-green-600 dark:text-green-400">${{ summary.total_fees|default:"0"|floatformat:0 }}</div>
+        <div class="text-2xl font-bold text-green-600 dark:text-green-400">${{ summary.total_fees|default:"0"|floatformat:0|intcomma }}</div>
       </div>
       <div class="text-center">
         <div class="text-xs text-gray-500 dark:text-gray-400">Unpaid</div>
-        <div class="text-2xl font-bold text-red-600 dark:text-red-400">${{ summary.unpaid_fees|default:"0"|floatformat:0 }}</div>
+        <div class="text-2xl font-bold text-red-600 dark:text-red-400">${{ summary.unpaid_fees|default:"0"|floatformat:0|intcomma }}</div>
       </div>
       <div class="text-center">
         <div class="text-xs text-gray-500 dark:text-gray-400">Miles</div>
-        <div class="text-2xl font-bold text-gray-700 dark:text-gray-300">{{ summary.total_mileage|default:"0.0"|floatformat:1 }}</div>
+        <div class="text-2xl font-bold text-gray-700 dark:text-gray-300">{{ summary.total_mileage|default:"0.0"|floatformat:1|intcomma }}</div>
       </div>
     </div>
 
@@ -113,7 +114,8 @@
         <td></td>
       </tr>
       {% for game in ds_games %}
-      <tr class="mg-{{ mid }} border-t border-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800{% if month_label != expand_month %} hidden{% endif %}">
+      <tr class="mg-{{ mid }} border-t border-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800{% if month_label != expand_month %} hidden{% endif %}"
+          data-paid="{% if game.fee_paid or game.is_volunteer %}true{% else %}false{% endif %}">
         <td class="py-2 pl-8"></td>
         <td class="px-4 py-2">{{ game.league.organization }}</td>
         <td class="px-4 py-2">{% if game.position %}{{ game.position }}{% endif %}</td>
@@ -159,7 +161,10 @@
     </tbody>
   </table>
 
-  <style>tr.hidden { display: none !important; }</style>
+  <style>
+    tr.hidden { display: none !important; }
+    tr.paid-hidden { display: none !important; }
+  </style>
   <script>
     function toggleMonth(id) {
       const rows = document.querySelectorAll(`.mg-${id}`);
@@ -202,5 +207,28 @@
         }
       });
     });
+
+    (function() {
+      const CLS_ACTIVE = ['bg-blue-600', 'text-white'];
+      const CLS_INACTIVE = ['bg-white', 'dark:bg-gray-700', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-gray-600'];
+      const btnUnpaid = document.getElementById('btn-paid-unpaid');
+      const btnAll = document.getElementById('btn-paid-all');
+
+      function applyPaidFilter(filter) {
+        document.querySelectorAll('tr[data-paid]').forEach(r => {
+          r.classList.toggle('paid-hidden', filter === 'unpaid' && r.dataset.paid === 'true');
+        });
+        btnUnpaid.classList.toggle('bg-blue-600', filter === 'unpaid');
+        btnUnpaid.classList.toggle('text-white', filter === 'unpaid');
+        CLS_INACTIVE.forEach(c => btnUnpaid.classList.toggle(c, filter !== 'unpaid'));
+        btnAll.classList.toggle('bg-blue-600', filter === 'all');
+        btnAll.classList.toggle('text-white', filter === 'all');
+        CLS_INACTIVE.forEach(c => btnAll.classList.toggle(c, filter !== 'all'));
+      }
+
+      btnUnpaid.addEventListener('click', () => applyPaidFilter('unpaid'));
+      btnAll.addEventListener('click', () => applyPaidFilter('all'));
+      applyPaidFilter('{{ f_paid }}');
+    })();
   </script>
 {% endblock %}

--- a/tracker/templates/game/list.html
+++ b/tracker/templates/game/list.html
@@ -14,39 +14,39 @@
 
     <div class="flex-1 bg-white dark:bg-gray-800 rounded shadow p-4 flex flex-row gap-6">
 
-    <form method="get" action="{% url 'game_list' %}" class="flex flex-col justify-between" style="min-width:160px;">
+    <div class="flex flex-col justify-between" style="min-width:160px;">
       {% with sel_cls="w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200" %}
-      <select name="filter_year" onchange="this.form.submit()" class="{{ sel_cls }}">
+      <select id="sel-year" name="filter_year" class="{{ sel_cls }}">
         <option value="">All Years</option>
         {% for year in available_years %}
           <option value="{{ year }}" {% if f_year == year|stringformat:"s" %}selected{% endif %}>{{ year }}</option>
         {% endfor %}
       </select>
-      <select name="filter_league" onchange="this.form.submit()" class="{{ sel_cls }}">
+      <select id="sel-league" name="filter_league" class="{{ sel_cls }}">
         <option value="">All Leagues</option>
         {% for league in available_leagues %}
           <option value="{{ league }}" {% if f_league == league %}selected{% endif %}>{{ league }}</option>
         {% endfor %}
       </select>
-      <select name="filter_assignor" onchange="this.form.submit()" class="{{ sel_cls }}">
+      <select id="sel-assignor" name="filter_assignor" class="{{ sel_cls }}">
         <option value="">All Assignors</option>
         {% for assignor in available_assignors %}
           <option value="{{ assignor }}" {% if f_assignor == assignor %}selected{% endif %}>{{ assignor }}</option>
         {% endfor %}
       </select>
-      <select name="filter_position" onchange="this.form.submit()" class="{{ sel_cls }}">
+      <select id="sel-position" name="filter_position" class="{{ sel_cls }}">
         <option value="">All Positions</option>
         {% for position in available_positions %}
           <option value="{{ position }}" {% if f_position == position %}selected{% endif %}>{{ position }}</option>
         {% endfor %}
       </select>
-      <select name="filter_site" onchange="this.form.submit()" class="{{ sel_cls }}">
+      <select id="sel-site" name="filter_site" class="{{ sel_cls }}">
         <option value="">All Sites</option>
         {% for site in available_sites %}
           <option value="{{ site }}" {% if f_site == site %}selected{% endif %}>{{ site }}</option>
         {% endfor %}
       </select>
-      <a href="{% url 'game_list' %}" class="w-full text-center text-sm px-2 py-1 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-300 dark:hover:bg-gray-500 transition">Clear Filters</a>
+      <button type="button" id="btn-clear-filters" class="w-full text-center text-sm px-2 py-1 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-300 dark:hover:bg-gray-500 transition">Clear Filters</button>
 
       <div class="flex rounded overflow-hidden border border-gray-300 dark:border-gray-600 mt-1">
         <button type="button" id="btn-paid-unpaid"
@@ -59,7 +59,7 @@
         </button>
       </div>
       {% endwith %}
-    </form>
+    </div>
 
     <div class="flex-1 grid grid-cols-1 lg:grid-cols-2 gap-4 content-center">
       <div class="text-center">
@@ -99,6 +99,7 @@
       {% for month_label, date_site_groups, month_count in games_by_month %}
       {% with mid=forloop.counter %}
       <tr class="cursor-pointer select-none bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+          data-month-id="{{ mid }}"
           onclick="toggleMonth({{ mid }})">
         <td colspan="7" class="px-4 py-2 font-semibold text-gray-700 dark:text-gray-200">
           <span id="chev-{{ mid }}">{% if month_label == expand_month %}▼{% else %}▶{% endif %}</span>
@@ -107,7 +108,9 @@
         </td>
       </tr>
       {% for game_date, site_name, trip_mileage, trip_mileage_paid, ds_games in date_site_groups %}
-      <tr class="mg-{{ mid }} bg-blue-50 dark:bg-blue-900/20 border-t border-gray-200{% if month_label != expand_month %} hidden{% endif %}">
+      <tr class="mg-{{ mid }} bg-blue-50 dark:bg-blue-900/20 border-t border-gray-200{% if month_label != expand_month %} hidden{% endif %}"
+          data-month-id="{{ mid }}"
+          data-trip-id="{{ mid }}-{{ forloop.counter }}">
         <td class="px-4 py-1 text-sm font-medium text-blue-800 dark:text-blue-200">{{ game_date|date:"D, N j" }} — {{ site_name }}</td>
         <td colspan="4"></td>
         <td class="px-4 py-1 text-sm text-gray-600 dark:text-gray-400">{% if trip_mileage > 0 %}{{ trip_mileage|floatformat:1 }} mi{% endif %}</td>
@@ -115,7 +118,14 @@
       </tr>
       {% for game in ds_games %}
       <tr class="mg-{{ mid }} border-t border-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800{% if month_label != expand_month %} hidden{% endif %}"
-          data-paid="{% if game.fee_paid or game.is_volunteer %}true{% else %}false{% endif %}">
+          data-month-id="{{ mid }}"
+          data-trip-id="{{ mid }}-{{ forloop.parentloop.counter }}"
+          data-paid="{% if game.fee_paid or game.is_volunteer %}true{% else %}false{% endif %}"
+          data-year="{{ game.date.year }}"
+          data-league="{{ game.league.organization|default:'' }}"
+          data-assignor="{{ game.league.assignor|default:'' }}"
+          data-position="{{ game.position|default:'' }}"
+          data-site="{{ game.site.name|default:'' }}">
         <td class="py-2 pl-8"></td>
         <td class="px-4 py-2">{{ game.league.organization }}</td>
         <td class="px-4 py-2">{% if game.position %}{{ game.position }}{% endif %}</td>
@@ -156,22 +166,38 @@
       {% endfor %}
       {% endwith %}
       {% empty %}
-      <tr><td colspan="7" class="px-4 py-6 text-center text-gray-400 dark:text-gray-500">No games match the current filters.</td></tr>
+      <tr><td colspan="7" class="px-4 py-6 text-center text-gray-400 dark:text-gray-500">No games found.</td></tr>
       {% endfor %}
     </tbody>
   </table>
 
   <style>
-    tr.hidden { display: none !important; }
-    tr.paid-hidden { display: none !important; }
+    tr.hidden        { display: none !important; }
+    tr.filter-hidden { display: none !important; }
+    @keyframes rowAppear {
+      from { opacity: 0; transform: translateY(-4px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    tr.mg-enter { animation: rowAppear 0.2s ease forwards; }
   </style>
   <script>
     function toggleMonth(id) {
       const rows = document.querySelectorAll(`.mg-${id}`);
       const chev = document.getElementById(`chev-${id}`);
       const collapsed = rows.length > 0 && rows[0].classList.contains('hidden');
-      rows.forEach(r => r.classList.toggle('hidden', !collapsed));
-      chev.textContent = collapsed ? '▼' : '▶';
+      if (collapsed) {
+        rows.forEach(r => {
+          if (!r.classList.contains('filter-hidden')) {
+            r.classList.remove('hidden');
+            r.classList.add('mg-enter');
+            r.addEventListener('animationend', () => r.classList.remove('mg-enter'), { once: true });
+          }
+        });
+        chev.textContent = '▼';
+      } else {
+        rows.forEach(r => r.classList.add('hidden'));
+        chev.textContent = '▶';
+      }
     }
 
     const ICON_PAID = `<svg class="inline-block text-green-600" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`;
@@ -198,6 +224,9 @@
           const data = await res.json();
           btn.dataset.paid = data.fee_paid ? 'true' : 'false';
           btn.innerHTML = data.fee_paid ? ICON_PAID : ICON_UNPAID;
+          // sync the row's data-paid so filtering reflects the new state
+          btn.closest('tr[data-paid]').dataset.paid = btn.dataset.paid;
+          applyAllFilters();
         } catch {
           btn.dataset.paid = wasPaid ? 'true' : 'false';
           btn.innerHTML = wasPaid ? ICON_PAID : ICON_UNPAID;
@@ -208,27 +237,74 @@
       });
     });
 
-    (function() {
-      const CLS_ACTIVE = ['bg-blue-600', 'text-white'];
-      const CLS_INACTIVE = ['bg-white', 'dark:bg-gray-700', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-gray-600'];
-      const btnUnpaid = document.getElementById('btn-paid-unpaid');
-      const btnAll = document.getElementById('btn-paid-all');
+    const CLS_INACTIVE = ['bg-white', 'dark:bg-gray-700', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-gray-600'];
+    const btnUnpaid = document.getElementById('btn-paid-unpaid');
+    const btnAll    = document.getElementById('btn-paid-all');
+    let currentPaidFilter = '{{ f_paid }}';
 
-      function applyPaidFilter(filter) {
-        document.querySelectorAll('tr[data-paid]').forEach(r => {
-          r.classList.toggle('paid-hidden', filter === 'unpaid' && r.dataset.paid === 'true');
-        });
-        btnUnpaid.classList.toggle('bg-blue-600', filter === 'unpaid');
-        btnUnpaid.classList.toggle('text-white', filter === 'unpaid');
-        CLS_INACTIVE.forEach(c => btnUnpaid.classList.toggle(c, filter !== 'unpaid'));
-        btnAll.classList.toggle('bg-blue-600', filter === 'all');
-        btnAll.classList.toggle('text-white', filter === 'all');
-        CLS_INACTIVE.forEach(c => btnAll.classList.toggle(c, filter !== 'all'));
-      }
+    function applyAllFilters() {
+      const fYear     = document.getElementById('sel-year').value;
+      const fLeague   = document.getElementById('sel-league').value;
+      const fAssignor = document.getElementById('sel-assignor').value;
+      const fPosition = document.getElementById('sel-position').value;
+      const fSite     = document.getElementById('sel-site').value;
 
-      btnUnpaid.addEventListener('click', () => applyPaidFilter('unpaid'));
-      btnAll.addEventListener('click', () => applyPaidFilter('all'));
-      applyPaidFilter('{{ f_paid }}');
-    })();
+      const visibleTrips  = new Set();
+      const visibleMonths = new Set();
+
+      // filter game rows
+      document.querySelectorAll('tr[data-year]').forEach(r => {
+        const hide =
+          (fYear     && r.dataset.year     !== fYear)     ||
+          (fLeague   && r.dataset.league   !== fLeague)   ||
+          (fAssignor && r.dataset.assignor !== fAssignor) ||
+          (fPosition && r.dataset.position !== fPosition) ||
+          (fSite     && r.dataset.site     !== fSite)     ||
+          (currentPaidFilter === 'unpaid'  && r.dataset.paid === 'true');
+        r.classList.toggle('filter-hidden', hide);
+        if (!hide) {
+          visibleTrips.add(r.dataset.tripId);
+          visibleMonths.add(r.dataset.monthId);
+        }
+      });
+
+      // show/hide trip sub-headers
+      document.querySelectorAll('tr[data-trip-id]:not([data-year])').forEach(r => {
+        r.classList.toggle('filter-hidden', !visibleTrips.has(r.dataset.tripId));
+      });
+
+      // show/hide month headers
+      document.querySelectorAll('tr[data-month-id]:not([data-trip-id])').forEach(r => {
+        r.classList.toggle('filter-hidden', !visibleMonths.has(r.dataset.monthId));
+      });
+    }
+
+    function setPaidFilter(filter) {
+      currentPaidFilter = filter;
+      btnUnpaid.classList.toggle('bg-blue-600', filter === 'unpaid');
+      btnUnpaid.classList.toggle('text-white',  filter === 'unpaid');
+      CLS_INACTIVE.forEach(c => btnUnpaid.classList.toggle(c, filter !== 'unpaid'));
+      btnAll.classList.toggle('bg-blue-600', filter === 'all');
+      btnAll.classList.toggle('text-white',  filter === 'all');
+      CLS_INACTIVE.forEach(c => btnAll.classList.toggle(c, filter !== 'all'));
+      applyAllFilters();
+    }
+
+    btnUnpaid.addEventListener('click', () => setPaidFilter('unpaid'));
+    btnAll.addEventListener('click',    () => setPaidFilter('all'));
+
+    ['sel-year', 'sel-league', 'sel-assignor', 'sel-position', 'sel-site'].forEach(id => {
+      document.getElementById(id).addEventListener('change', applyAllFilters);
+    });
+
+    document.getElementById('btn-clear-filters').addEventListener('click', () => {
+      ['sel-year', 'sel-league', 'sel-assignor', 'sel-position', 'sel-site'].forEach(id => {
+        document.getElementById(id).value = '';
+      });
+      applyAllFilters();
+    });
+
+    // initialize
+    setPaidFilter('{{ f_paid }}');
   </script>
 {% endblock %}

--- a/tracker/templates/game/stats.html
+++ b/tracker/templates/game/stats.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load humanize %}
 
 {% block title %} Stats {% endblock %}
 
@@ -6,173 +7,236 @@
 
 <h2 class="text-2xl font-bold mb-6">Stats</h2>
 
-{% with headers="Games,Total Fees,Paid Fees,Unpaid Fees,Total Miles" %}
+<style>
+  .stats-body {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 0.25s ease-in-out;
+  }
+  .stats-body.stats-collapsed {
+    grid-template-rows: 0fr;
+  }
+  .stats-body > div {
+    overflow: hidden;
+  }
+  .stats-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    text-align: left;
+    font-size: 1.125rem;
+    font-weight: 600;
+    padding: 0.375rem 0.75rem;
+    margin-bottom: 0.5rem;
+    border: 1px solid;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.15s;
+  }
+</style>
+
+{% with btn_cls="stats-toggle border-gray-300 dark:border-gray-500 text-gray-800 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400" %}
+{% with th_cls="px-4 py-2 text-right text-gray-700 dark:text-gray-300" %}
 
 {# By Year #}
-<section class="mb-8">
-  <h3 class="text-xl font-semibold mb-3 text-gray-800 dark:text-gray-200">By Year</h3>
-  <div class="overflow-x-auto">
-    <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
-      <thead class="bg-gray-100 dark:bg-gray-700">
-        <tr>
-          <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Year</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in by_year %}
-        <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
-          <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.year }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+<section class="mb-6">
+  <button type="button" class="{{ btn_cls }}" aria-expanded="true" data-target="section-year">
+    <span class="chevron">▼</span> Year
+  </button>
+  <div id="section-year" class="stats-body">
+    <div class="overflow-x-auto">
+      <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
+        <thead class="bg-gray-100 dark:bg-gray-700">
+          <tr>
+            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300"></th>
+            <th class="{{ th_cls }}">Games</th>
+            <th class="{{ th_cls }}">Total Fees</th>
+            <th class="{{ th_cls }}">Paid</th>
+            <th class="{{ th_cls }}">Unpaid</th>
+            <th class="{{ th_cls }}">Miles</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in by_year %}
+          <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
+            <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.year }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1|intcomma }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>
 
 {# By League #}
-<section class="mb-8">
-  <h3 class="text-xl font-semibold mb-3 text-gray-800 dark:text-gray-200">By League</h3>
-  <div class="overflow-x-auto">
-    <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
-      <thead class="bg-gray-100 dark:bg-gray-700">
-        <tr>
-          <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">League</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in by_league %}
-        <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
-          <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.league__organization|default:"—" }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+<section class="mb-6">
+  <button type="button" class="{{ btn_cls }}" aria-expanded="true" data-target="section-league">
+    <span class="chevron">▼</span> League
+  </button>
+  <div id="section-league" class="stats-body">
+    <div class="overflow-x-auto">
+      <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
+        <thead class="bg-gray-100 dark:bg-gray-700">
+          <tr>
+            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300"></th>
+            <th class="{{ th_cls }}">Games</th>
+            <th class="{{ th_cls }}">Total Fees</th>
+            <th class="{{ th_cls }}">Paid</th>
+            <th class="{{ th_cls }}">Unpaid</th>
+            <th class="{{ th_cls }}">Miles</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in by_league %}
+          <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
+            <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.league__organization|default:"—" }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1|intcomma }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>
 
 {# By Assignor #}
-<section class="mb-8">
-  <h3 class="text-xl font-semibold mb-3 text-gray-800 dark:text-gray-200">By Assignor</h3>
-  <div class="overflow-x-auto">
-    <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
-      <thead class="bg-gray-100 dark:bg-gray-700">
-        <tr>
-          <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Assignor</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in by_assignor %}
-        <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
-          <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.league__assignor|default:"—" }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+<section class="mb-6">
+  <button type="button" class="{{ btn_cls }}" aria-expanded="false" data-target="section-assignor">
+    <span class="chevron">▶</span> Assignor
+  </button>
+  <div id="section-assignor" class="stats-body stats-collapsed">
+    <div class="overflow-x-auto">
+      <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
+        <thead class="bg-gray-100 dark:bg-gray-700">
+          <tr>
+            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300"></th>
+            <th class="{{ th_cls }}">Games</th>
+            <th class="{{ th_cls }}">Total Fees</th>
+            <th class="{{ th_cls }}">Paid</th>
+            <th class="{{ th_cls }}">Unpaid</th>
+            <th class="{{ th_cls }}">Miles</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in by_assignor %}
+          <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
+            <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.league__assignor|default:"—" }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1|intcomma }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>
 
 {# By Position #}
-<section class="mb-8">
-  <h3 class="text-xl font-semibold mb-3 text-gray-800 dark:text-gray-200">By Position</h3>
-  <div class="overflow-x-auto">
-    <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
-      <thead class="bg-gray-100 dark:bg-gray-700">
-        <tr>
-          <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Position</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in by_position %}
-        <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
-          <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.position|default:"—" }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+<section class="mb-6">
+  <button type="button" class="{{ btn_cls }}" aria-expanded="false" data-target="section-position">
+    <span class="chevron">▶</span> Position
+  </button>
+  <div id="section-position" class="stats-body stats-collapsed">
+    <div class="overflow-x-auto">
+      <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
+        <thead class="bg-gray-100 dark:bg-gray-700">
+          <tr>
+            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300"></th>
+            <th class="{{ th_cls }}">Games</th>
+            <th class="{{ th_cls }}">Total Fees</th>
+            <th class="{{ th_cls }}">Paid</th>
+            <th class="{{ th_cls }}">Unpaid</th>
+            <th class="{{ th_cls }}">Miles</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in by_position %}
+          <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
+            <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.position|default:"—" }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1|intcomma }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>
 
 {# By Site #}
-<section class="mb-8">
-  <h3 class="text-xl font-semibold mb-3 text-gray-800 dark:text-gray-200">By Site</h3>
-  <div class="overflow-x-auto">
-    <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
-      <thead class="bg-gray-100 dark:bg-gray-700">
-        <tr>
-          <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Site</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Games</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Total Fees</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Paid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Unpaid</th>
-          <th class="px-4 py-2 text-right text-gray-700 dark:text-gray-300">Miles</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in by_site %}
-        <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
-          <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.site__name|default:"—" }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0 }}</td>
-          <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1 }}</td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+<section class="mb-6">
+  <button type="button" class="{{ btn_cls }}" aria-expanded="false" data-target="section-site">
+    <span class="chevron">▶</span> Site
+  </button>
+  <div id="section-site" class="stats-body stats-collapsed">
+    <div class="overflow-x-auto">
+      <table class="min-w-full border border-gray-200 bg-white dark:bg-gray-800 rounded shadow">
+        <thead class="bg-gray-100 dark:bg-gray-700">
+          <tr>
+            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300"></th>
+            <th class="{{ th_cls }}">Games</th>
+            <th class="{{ th_cls }}">Total Fees</th>
+            <th class="{{ th_cls }}">Paid</th>
+            <th class="{{ th_cls }}">Unpaid</th>
+            <th class="{{ th_cls }}">Miles</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in by_site %}
+          <tr class="border-t hover:bg-gray-50 dark:hover:bg-gray-700">
+            <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ row.site__name|default:"—" }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.count|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">${{ row.total_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-green-600 dark:text-green-400">${{ row.paid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-red-600 dark:text-red-400">${{ row.unpaid_fees|default:"0"|floatformat:0|intcomma }}</td>
+            <td class="px-4 py-2 text-right text-gray-800 dark:text-gray-200">{{ row.total_mileage|default:"0.0"|floatformat:1|intcomma }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="px-4 py-4 text-center text-gray-500">No data</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>
 
 {% endwith %}
+{% endwith %}
+
+<script>
+  document.querySelectorAll('.stats-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      const target = document.getElementById(btn.dataset.target);
+      btn.setAttribute('aria-expanded', String(!expanded));
+      btn.querySelector('.chevron').textContent = expanded ? '▶' : '▼';
+      target.classList.toggle('stats-collapsed', expanded);
+    });
+  });
+</script>
 
 {% endblock %}

--- a/tracker/tests.py
+++ b/tracker/tests.py
@@ -426,7 +426,7 @@ class GameViewsTest(TestCase):
         response = self.client.get(reverse("game_list"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Test Site")
-        self.assertIn("games", response.context)
+        self.assertIn("games_by_month", response.context)
 
     def test_game_list_view_requires_login(self):
         """Test game list view requires authentication."""

--- a/tracker/views.py
+++ b/tracker/views.py
@@ -74,16 +74,6 @@ def game_list(request: HttpRequest) -> HttpResponse:
     f_paid = request.GET.get("filter_paid", "unpaid")
 
     summary_qs = games
-    if f_year:
-        summary_qs = summary_qs.filter(date__year=f_year)
-    if f_league:
-        summary_qs = summary_qs.filter(league__organization=f_league)
-    if f_assignor:
-        summary_qs = summary_qs.filter(league__assignor=f_assignor)
-    if f_position:
-        summary_qs = summary_qs.filter(position=f_position)
-    if f_site:
-        summary_qs = summary_qs.filter(site__name=f_site)
     eff_fee = Case(
         When(fee__isnull=False, then=F("fee")),
         default=F("league__game_fee"),

--- a/tracker/views.py
+++ b/tracker/views.py
@@ -84,9 +84,6 @@ def game_list(request: HttpRequest) -> HttpResponse:
         summary_qs = summary_qs.filter(position=f_position)
     if f_site:
         summary_qs = summary_qs.filter(site__name=f_site)
-    if f_paid == "unpaid":
-        summary_qs = summary_qs.filter(fee_paid=False, is_volunteer=False)
-
     eff_fee = Case(
         When(fee__isnull=False, then=F("fee")),
         default=F("league__game_fee"),


### PR DESCRIPTION
## Summary
Converts the game list Unpaid/All toggle from a page-reload link to instant client-side filtering. Replaces the static stats page section headers with collapsible bordered toggle buttons. Adds thousands-separator formatting to all numeric values on both pages.

## Changes
- **Game list — client-side paid filter** (`list.html`, `views.py`): Unpaid/All links replaced with JS buttons; all game rows now render in the DOM with a `data-paid` attribute; a `paid-hidden` CSS class is toggled on click with no network request. Server-side `f_paid` queryset filter removed — the initial tab state is still driven by the `f_paid` query param passed through context.
- **Game list — summary widget** (`list.html`): Metrics grid breakpoint raised from `sm:` to `lg:` so it stays single-column until there is enough viewport width for both the filter sidebar and the 2×2 grid to coexist comfortably.
- **Stats page — collapsible sections** (`stats.html`): Five `<h3>` headers replaced with bordered `<button>` toggles (left-side ▼/▶ chevron, label without "By" prefix). Year and League expand on load; Assignor, Position, and Site collapse. Smooth CSS grid-row transition animates open/close. First-column `<th>` removed from each table since the button already names the group.
- **Thousands separators** (`list.html`, `stats.html`, `settings.py`): `django.contrib.humanize` added to `INSTALLED_APPS`; `|intcomma` filter applied to all fee, game count, and mileage values on both pages.
- **Test fix** (`tests.py`): Stale assertion updated from `"games"` → `"games_by_month"` to match the current view context.

## How to test
1. **Paid filter**: Log in, navigate to `/games/`. Confirm default view shows only unpaid games. Click **All** — paid games appear instantly, no page reload. Click **Unpaid** — they hide again. Reload with `?filter_paid=all` in the URL; confirm **All** tab is pre-selected.
2. **Stats collapsible**: Navigate to `/stats/`. Confirm Year and League tables are visible; Assignor, Position, Site are collapsed. Click a collapsed section — table slides open with animation. Click again — it closes. Verify keyboard tab + Enter works on each button.
3. **Thousands separators**: With enough data, confirm values like `$1,234` and `1,234.5` render correctly on both game list summary and stats tables.
4. **Tests**: `python3 manage.py test` — all 55 pass.

## Risk assessment
- Removing the server-side `f_paid` filter means the game list always fetches all matching games regardless of paid status. For users with very large game histories this increases the initial query result set, though the tradeoff was intentional (all rows needed in DOM for client-side filtering). The summary widget now reflects all-games totals rather than scoping to unpaid, which changes the "Games" and "Total Fees" numbers when the Unpaid tab is active.
- The `paid-hidden` / month-collapse (`hidden`) CSS classes are independent — collapsing a month then switching filter modes won't expose or lose rows incorrectly, but this interaction should be spot-checked manually.
- `django.contrib.humanize` is a built-in Django app with no new dependencies.

## Related issues
- Closes #81
- Closes #83